### PR TITLE
docs: bump version to v1.0.4 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.4] - 2026-04-04
+
+### Fixed
+- Homebrew cask version mismatch - ensure distribution version stays in sync with main repository
+
 ## [v1.0.3] - 2026-04-04
 
 ### Added


### PR DESCRIPTION
Add entry for v1.0.4 to fix Homebrew cask version mismatch with main repository.