### PR TITLE
fix: parse all gem dependency groups from gemspec files

### DIFF
--- a/internal/gemfile/gemspec_parser.go
+++ b/internal/gemfile/gemspec_parser.go
@@ -71,9 +71,9 @@ func ParseGemspec(path string) (*Gemfile, error) {
 
 	// Regex patterns for dependency declarations
 	// Matches: add_runtime_dependency 'gem_name', '>= 1.0' or add_development_dependency, etc.
-	// Also matches spec.add_runtime_dependency pattern
-	runtimeDepRegex := regexp.MustCompile(`(?:spec\.)?add_(?:runtime_)?dependency\s+['"]([^'"]+)['"]\s*(?:,\s*['"]([^'"]+)['"])?`)
-	developmentDepRegex := regexp.MustCompile(`(?:spec\.)?add_development_dependency\s+['"]([^'"]+)['"]\s*(?:,\s*['"]([^'"]+)['"])?`)
+	// Also matches spec.add_runtime_dependency and s.add_runtime_dependency patterns
+	runtimeDepRegex := regexp.MustCompile(`(?:spec\.|s\.)?add_(?:runtime_)?dependency\s+['"]([^'"]+)['"]\s*(?:,\s*['"]([^'"]+)['"])?`)
+	developmentDepRegex := regexp.MustCompile(`(?:spec\.|s\.)?add_development_dependency\s+['"]([^'"]+)['"]\s*(?:,\s*['"]([^'"]+)['"])?`)
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -121,7 +121,7 @@ func ParseGemspec(path string) (*Gemfile, error) {
 					Name:         gemName,
 					Version:      version,
 					Dependencies: []string{},
-					Groups:       []string{},
+					Groups:       []string{"production"},
 					IsFirstLevel: true,
 				}
 

--- a/internal/gemfile/gemspec_parser_test.go
+++ b/internal/gemfile/gemspec_parser_test.go
@@ -45,9 +45,16 @@ end
 		if !rail.IsFirstLevel {
 			t.Error("Expected rails to be first-level")
 		}
-		// Rails should not be in development group
-		if len(rail.Groups) > 0 {
-			t.Errorf("Expected rails to have no groups, got %v", rail.Groups)
+		// Rails should be in production group
+		hasProduction := false
+		for _, g := range rail.Groups {
+			if g == "production" {
+				hasProduction = true
+				break
+			}
+		}
+		if !hasProduction {
+			t.Errorf("Expected rails to be in production group, got %v", rail.Groups)
 		}
 	}
 
@@ -101,6 +108,64 @@ end
 
 	if _, ok := gf.Gems["sinatra"]; !ok {
 		t.Error("Expected 'sinatra' gem to be parsed from spec. prefix")
+	}
+}
+
+func TestParseGemspec_WithSPrefix(t *testing.T) {
+	tmpDir := t.TempDir()
+	gemspecPath := filepath.Join(tmpDir, "test.gemspec")
+
+	// Test with s. prefix (most common pattern in real gemspecs)
+	gemspecContent := `Gem::Specification.new do |s|
+  s.name = "example-gem"
+  s.version = "1.0.0"
+  s.add_dependency "rails", "~> 7.0"
+  s.add_dependency "sqlite3", "~> 1.4"
+  s.add_development_dependency "rspec", "~> 3.0"
+end
+`
+
+	if err := os.WriteFile(gemspecPath, []byte(gemspecContent), 0644); err != nil {
+		t.Fatalf("Failed to write test gemspec: %v", err)
+	}
+
+	gf, err := ParseGemspec(gemspecPath)
+	if err != nil {
+		t.Fatalf("Failed to parse gemspec: %v", err)
+	}
+
+	// Should parse all 3 gems
+	if len(gf.Gems) != 3 {
+		t.Errorf("Expected 3 gems from s. prefix, got %d", len(gf.Gems))
+	}
+
+	// Check runtime dependencies
+	if rails, ok := gf.Gems["rails"]; !ok {
+		t.Error("Expected 'rails' gem from s.add_dependency")
+	} else if rails.Version != "~> 7.0" {
+		t.Errorf("Expected rails version '~> 7.0', got '%s'", rails.Version)
+	}
+
+	if sqlite3, ok := gf.Gems["sqlite3"]; !ok {
+		t.Error("Expected 'sqlite3' gem from s.add_dependency")
+	} else if sqlite3.Version != "~> 1.4" {
+		t.Errorf("Expected sqlite3 version '~> 1.4', got '%s'", sqlite3.Version)
+	}
+
+	// Check development dependency
+	if rspec, ok := gf.Gems["rspec"]; !ok {
+		t.Error("Expected 'rspec' gem from s.add_development_dependency")
+	} else {
+		hasDev := false
+		for _, g := range rspec.Groups {
+			if g == "development" {
+				hasDev = true
+				break
+			}
+		}
+		if !hasDev {
+			t.Error("Expected rspec to be in development group")
+		}
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -350,26 +350,27 @@ func (m *Model) loadProject(path string) {
 	// It's a directory (or doesn't exist yet)
 	m.ProjectPath = absPath
 
-	// Try to find a lock file (gems.locked or Gemfile.lock)
-	lockFile := gemfile.FindLockFile(m.ProjectPath)
-	if lockFile != "" {
-		m.GemfileLockPath = lockFile
-		m.GemfileSource = filepath.Base(lockFile)
-		logger.Info("Project loaded from lock file: %s", m.GemfileSource)
-		return
-	}
-
-	// Try to find a .gemspec file
+	// For gem projects: try to find a .gemspec file FIRST (it's the authoritative source)
+	// This ensures we get all production dependencies, not just what's in Gemfile.lock
 	files, err := os.ReadDir(m.ProjectPath)
 	if err == nil {
 		for _, file := range files {
 			if !file.IsDir() && strings.HasSuffix(file.Name(), ".gemspec") {
 				m.GemfileLockPath = filepath.Join(m.ProjectPath, file.Name())
 				m.GemfileSource = file.Name()
-				logger.Info("Project loaded from gemspec file: %s", m.GemfileSource)
+				logger.Info("Project loaded from gemspec file: %s (gem project)", m.GemfileSource)
 				return
 			}
 		}
+	}
+
+	// For Rails/Bundler projects: try to find a lock file (gems.locked or Gemfile.lock)
+	lockFile := gemfile.FindLockFile(m.ProjectPath)
+	if lockFile != "" {
+		m.GemfileLockPath = lockFile
+		m.GemfileSource = filepath.Base(lockFile)
+		logger.Info("Project loaded from lock file: %s", m.GemfileSource)
+		return
 	}
 
 	// Fallback to Gemfile.lock (default behavior for backward compatibility)


### PR DESCRIPTION
Fix two issues with gemspec parsing:

1. Regex patterns now match 's.' prefix (most common in real gemspecs)
   - Updated both add_dependency and add_development_dependency patterns
   - Previously only matched 'spec.' prefix, missing production dependencies
   - Real gemspecs use |s| as the block parameter in Gem::Specification.new

2. Reversed file loading priority: check .gemspec before Gemfile.lock
   - For gem projects, .gemspec is the authoritative source of all dependencies
   - Gemfile.lock for local gems only lists dev dependencies in DEPENDENCIES section
   - Production deps buried in PATH section when gem has a local gemspec
   - Rails projects still work (no gemspec, so falls back to Gemfile.lock)

3. Production dependencies now explicitly marked with ["production"] group
   - Distinguishes from development dependencies
   - Consistent with Gemfile.lock parsing behavior

Tests:
- All 78 tests passing
- Updated existing gemspec tests to expect "production" group
- Added TestParseGemspec_WithSPrefix to verify s. prefix parsing

Fixes issue where gemtracker only showed development dependencies when analyzing a gem project that has both .gemspec and Gemfile.lock.