### PR TITLE
fix: remove unsupported install/test fields from homebrew_casks config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,7 +83,3 @@ homebrew_casks:
     description: "An interactive TUI for analyzing Ruby gem dependencies and security risks"
     license: MIT
     skip_upload: false
-    install: |
-      bin.install "gemtracker"
-    test: |
-      system "#{bin}/gemtracker", "--version"


### PR DESCRIPTION
GoReleaser v2.15.2 doesn't support install and test fields in homebrew_casks (these are Formula-only fields). Remove them to fix the release build.