### PR TITLE
chore: switch homebrew distribution from casks to formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,7 +73,7 @@ changelog:
       - '^test:'
       - typo
 
-homebrew_casks:
+brews:
   - repository:
       owner: spaquet
       name: homebrew-gemtracker
@@ -82,4 +82,8 @@ homebrew_casks:
     homepage: "https://github.com/spaquet/gemtracker"
     description: "An interactive TUI for analyzing Ruby gem dependencies and security risks"
     license: MIT
-    skip_upload: false
+    directory: Formula
+    install: |
+      bin.install "gemtracker"
+    test: |
+      system "#{bin}/gemtracker", "--version"


### PR DESCRIPTION
- Change GoReleaser config from homebrew_casks to brews section
- Update to publish formula to Formula/ directory
- Fixes code signing issues by staying with formula distribution
- Formula handles both macOS and Linux installations