### PR TITLE
fix: switch from homebrew_casks to homebrew formula deployment

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,7 +73,7 @@ changelog:
       - '^test:'
       - typo
 
-homebrew_casks:
+homebrew:
   - repository:
       owner: spaquet
       name: homebrew-gemtracker


### PR DESCRIPTION
## Summary

Switch GoReleaser configuration from `homebrew_casks` to `homebrew` to properly generate Formula instead of Cask files. This fixes the release workflow so users installing with `brew install gemtracker` get the correct version.

**Related issues:**
- Cask was at 1.2.2 but Formula was stuck at 1.2.1
- Users saw warning about treating as formula
- Future releases will update the correct Formula file

## Changes
- Changed `homebrew_casks:` to `homebrew:` in `.goreleaser.yml`
- Formula file in homebrew-gemtracker tap already updated to 1.2.2
- Cask folder removed from tap (no longer needed)