### PR TITLE
fix: CVE regression issues in v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.2.3] - 2026-04-10
+
+### Fixed
+- **CVE Comment Modal Not Opening from Info View** - Pressing 'c' in CVE info modal now opens comment editor
+  - Added 'c' key handler to CVE info view for consistency
+  - Comments can now be edited from both main CVE list and detailed info modal
+- **CVE Acknowledgment Filter Not Working** - Complete refactor with checkbox support
+  - Changed from single-state cycling to multi-select checkbox filtering
+  - Now supports three independent filter states: Acknowledged, Ignored, Unacknowledged
+  - Users can select any combination of states with space bar (like severity filters)
+  - All three states are enabled by default (shows all vulnerabilities)
+  - Properly detects "Unacknowledged" as initial state (no comment on CVE)
+  - Fixed nil panic when filtering with no comments loaded
+
 ## [v1.2.1] - 2026-04-10
 
 ### Improved

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -262,25 +262,25 @@ type Model struct {
 	UpgradeableOffset         int
 
 	// CVE screen state
-	VulnerableGems          []*gemfile.GemStatus
-	CVECursor               int
-	CVEOffset               int
-	CVEInfoScroll           int                      // Scroll offset for CVE info modal content
-	CVEVulnerabilities      []*gemfile.Vulnerability // Actual vulnerability data from OSV.dev
-	UnfilteredCVEs          []*gemfile.Vulnerability // All CVEs before filtering
-	CVESelectedSeverities   map[string]bool          // "CRITICAL","HIGH","MODERATE","LOW" → true/false
-	CVEShowOnlyDirect       bool                     // Filter to show only direct dependency CVEs
-	CVEAcknowledgmentFilter string                   // "" (all), "acknowledged", or "unacknowledged"
-	CVEFilterMenuCursor     int                      // Position in the CVE filter menu
-	LastGemsSignature       string                   // SHA256 of last scanned gems
-	CVERefreshInProgress    bool                     // Is a CVE refresh happening in background?
-	CVELastScanTime         time.Time                // When was CVE data last scanned?
-	CVECacheLoadedAt        time.Time                // When was cache loaded?
-	CVECacheTTL             time.Duration            // Default: 1 hour
-	CVELastError            string                   // Last error message if scan failed
-	CVEInfoCachedCVEID      string                   // CVE ID of currently cached modal content
-	CVEInfoCachedLines      []string                 // Cached rendered lines for modal
-	CVEInfoCachedWidth      int                      // Terminal width when modal was cached
+	VulnerableGems           []*gemfile.GemStatus
+	CVECursor                int
+	CVEOffset                int
+	CVEInfoScroll            int                      // Scroll offset for CVE info modal content
+	CVEVulnerabilities       []*gemfile.Vulnerability // Actual vulnerability data from OSV.dev
+	UnfilteredCVEs           []*gemfile.Vulnerability // All CVEs before filtering
+	CVESelectedSeverities    map[string]bool          // "CRITICAL","HIGH","MODERATE","LOW" → true/false
+	CVEShowOnlyDirect        bool                     // Filter to show only direct dependency CVEs
+	CVEAcknowledgmentFilters map[string]bool          // "acknowledged", "ignored", "unacknowledged" → true/false
+	CVEFilterMenuCursor      int                      // Position in the CVE filter menu
+	LastGemsSignature        string                   // SHA256 of last scanned gems
+	CVERefreshInProgress     bool                     // Is a CVE refresh happening in background?
+	CVELastScanTime          time.Time                // When was CVE data last scanned?
+	CVECacheLoadedAt         time.Time                // When was cache loaded?
+	CVECacheTTL              time.Duration            // Default: 1 hour
+	CVELastError             string                   // Last error message if scan failed
+	CVEInfoCachedCVEID       string                   // CVE ID of currently cached modal content
+	CVEInfoCachedLines       []string                 // Cached rendered lines for modal
+	CVEInfoCachedWidth       int                      // Terminal width when modal was cached
 
 	// CVE comment modal state
 	CVEComments           *gemfile.CVEComments       // Loaded CVE comments from project
@@ -850,7 +850,7 @@ func (m *Model) shouldIncludeVulnerability(vuln *gemfile.Vulnerability) bool {
 	}
 
 	// Check acknowledgment filter
-	if m.CVEAcknowledgmentFilter != "" && !m.matchesAcknowledgmentFilter(vuln) {
+	if !m.matchesAcknowledgmentFilter(vuln) {
 		return false
 	}
 
@@ -869,17 +869,33 @@ func (m *Model) isDirectDependency(gemName string) bool {
 
 // matchesAcknowledgmentFilter checks if a vulnerability matches the acknowledgment filter.
 func (m *Model) matchesAcknowledgmentFilter(vuln *gemfile.Vulnerability) bool {
-	key := gemfile.GetCVECommentKey(vuln)
-	comment, exists := m.CVEComments.Entries[key]
-	isAcknowledged := exists && comment.Decision == gemfile.DecisionAcknowledged
+	// If no filters selected, include all
+	if !m.CVEAcknowledgmentFilters["acknowledged"] && !m.CVEAcknowledgmentFilters["ignored"] && !m.CVEAcknowledgmentFilters["unacknowledged"] {
+		return true
+	}
 
-	if m.CVEAcknowledgmentFilter == "acknowledged" {
-		return isAcknowledged
+	// Determine the vulnerability's acknowledgment state
+	var vulnState string
+	if m.CVEComments != nil {
+		key := gemfile.GetCVECommentKey(vuln)
+		comment, exists := m.CVEComments.Entries[key]
+		if exists && comment != nil {
+			if comment.Decision == gemfile.DecisionAcknowledged {
+				vulnState = "acknowledged"
+			} else if comment.Decision == gemfile.DecisionIgnored {
+				vulnState = "ignored"
+			} else {
+				vulnState = "unacknowledged"
+			}
+		} else {
+			vulnState = "unacknowledged"
+		}
+	} else {
+		vulnState = "unacknowledged"
 	}
-	if m.CVEAcknowledgmentFilter == "unacknowledged" {
-		return !isAcknowledged
-	}
-	return true
+
+	// Check if this state is selected in the filter
+	return m.CVEAcknowledgmentFilters[vulnState]
 }
 
 // initializeCVEFilters sets up the CVE filter state when vulnerabilities are loaded
@@ -893,7 +909,11 @@ func (m *Model) initializeCVEFilters(vulns []*gemfile.Vulnerability) {
 		"LOW":      true,
 	}
 	m.CVEShowOnlyDirect = false
-	m.CVEAcknowledgmentFilter = ""
+	m.CVEAcknowledgmentFilters = map[string]bool{
+		"acknowledged":   true,
+		"ignored":        true,
+		"unacknowledged": true,
+	}
 	m.CVEFilterMenuCursor = 0
 }
 

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -690,6 +690,10 @@ func (m *Model) handleCVEInfoKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 		return m, nil
+
+	case "c":
+		m.openCVECommentModal()
+		return m, nil
 	}
 
 	return m, nil
@@ -757,6 +761,7 @@ func (m *Model) openCVECommentModal() {
 		}
 	}
 
+	m.CurrentView = ViewCVEComment
 	m.CVECommentInput.Focus()
 }
 
@@ -1119,8 +1124,8 @@ func (m *Model) handleFilterMenuKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) handleCVEFilterMenuKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	// 4 severity options + 1 direct option + 1 acknowledgment option
-	totalOptions := 6
+	// 4 severity options + 1 direct option + 3 acknowledgment options
+	totalOptions := 8
 
 	switch msg.String() {
 	case "up":
@@ -1148,16 +1153,12 @@ func (m *Model) handleCVEFilterMenuKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 			m.CVESelectedSeverities["LOW"] = !m.CVESelectedSeverities["LOW"]
 		case 4: // Direct only
 			m.CVEShowOnlyDirect = !m.CVEShowOnlyDirect
-		case 5: // Acknowledgment filter
-			// Cycle through: "" (all) -> "acknowledged" -> "unacknowledged" -> ""
-			switch m.CVEAcknowledgmentFilter {
-			case "":
-				m.CVEAcknowledgmentFilter = "acknowledged"
-			case "acknowledged":
-				m.CVEAcknowledgmentFilter = "unacknowledged"
-			case "unacknowledged":
-				m.CVEAcknowledgmentFilter = ""
-			}
+		case 5: // Acknowledged
+			m.CVEAcknowledgmentFilters["acknowledged"] = !m.CVEAcknowledgmentFilters["acknowledged"]
+		case 6: // Ignored
+			m.CVEAcknowledgmentFilters["ignored"] = !m.CVEAcknowledgmentFilters["ignored"]
+		case 7: // Unacknowledged
+			m.CVEAcknowledgmentFilters["unacknowledged"] = !m.CVEAcknowledgmentFilters["unacknowledged"]
 		}
 		// Apply filters immediately
 		m.applyCVEFilters()

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -2354,18 +2354,22 @@ func (m *Model) renderCVEFilterModalBox() string {
 
 	lines = append(lines, "")
 
-	// Acknowledgment filter
-	ackStatus := ""
-	if m.CVEAcknowledgmentFilter == "acknowledged" {
-		ackStatus = " (acknowledged)"
-	} else if m.CVEAcknowledgmentFilter == "unacknowledged" {
-		ackStatus = " (unacknowledged)"
+	// Acknowledgment filter options
+	ackStates := []struct {
+		key   string
+		label string
+	}{
+		{"acknowledged", "Acknowledged"},
+		{"ignored", "Ignored"},
+		{"unacknowledged", "Unacknowledged"},
 	}
-	ackLine := "Filter by acknowledgment" + ackStatus
-	if m.CVEFilterMenuCursor == 5 {
-		lines = append(lines, RowSelectedStyle.Render("› "+ackLine))
-	} else {
-		lines = append(lines, "  "+ackLine)
+	for i, state := range ackStates {
+		ackLine := checkbox(m.CVEAcknowledgmentFilters[state.key]) + " " + state.label
+		if m.CVEFilterMenuCursor == 5+i {
+			lines = append(lines, RowSelectedStyle.Render("› "+ackLine))
+		} else {
+			lines = append(lines, "  "+ackLine)
+		}
 	}
 
 	// Footer hint


### PR DESCRIPTION
Fixes two regressions in CVE advisory comment functionality:

1. Pressing 'c' in CVE info modal now opens comment editor
   - Added missing 'c' key handler to handleCVEInfoKeys function
   - Comments can now be edited from both main CVE list and detailed info modal
   - Provides consistency between views

2. Fixed potential crash when filtering CVEs by acknowledgment status
   - Added nil check for CVEComments map in matchesAcknowledgmentFilter
   - Properly handles case when no comments are loaded yet
   - Treats uncommented vulnerabilities as "unacknowledged" when filtering