### PR TITLE
fix: update goreleaser config for v2.15.2 compatibility

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,7 +73,7 @@ changelog:
       - '^test:'
       - typo
 
-homebrew:
+brews:
   - repository:
       owner: spaquet
       name: homebrew-gemtracker


### PR DESCRIPTION
GoReleaser v2 renamed the 'homebrew' field to 'brews' at the top level. This change maintains the same Homebrew formula generation logic while conforming to the current GoReleaser configuration schema.