### PR TITLE
fix: Sentry CLI v3 compatibility and Project tab background

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,14 +58,6 @@ jobs:
           sentry-cli releases new "$VERSION"
           echo "✓ Release created"
 
-          # Upload source files for code context in error views
-          sentry-cli releases upload . \
-            --release "$VERSION" \
-            --ignore "dist,build,.git,.github" \
-            --ignore-flat "go.mod,go.sum,Makefile,.goreleaser.yml,LICENSE" \
-            --rewrite
-          echo "✓ Source files uploaded"
-
           # Link commits to the release for better context
           sentry-cli releases set-commits "$VERSION" --auto
           echo "✓ Commits linked"

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -2055,7 +2055,8 @@ func (m *Model) renderProjectInfo(height int) string {
 	title := "Project Information"
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color(ColorPrimary))
+		Foreground(lipgloss.Color(ColorPrimary)).
+		Background(lipgloss.Color("#262626"))
 
 	// Build info sections
 	var sections []string
@@ -2097,6 +2098,7 @@ func (m *Model) renderProjectInfo(height int) string {
 	sections = append(sections, lipgloss.NewStyle().
 		Bold(true).
 		Foreground(lipgloss.Color(ColorPrimary)).
+		Background(lipgloss.Color("#262626")).
 		Render("Statistics"))
 	sections = append(sections, "")
 
@@ -2110,7 +2112,8 @@ func (m *Model) renderProjectInfo(height int) string {
 		insecureLabel := fmt.Sprintf("🔓 Insecure Gem Sources (%d)", len(m.InsecureSourceGems))
 		insecureStyle := lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color(ColorWarning))
+			Foreground(lipgloss.Color(ColorWarning)).
+			Background(lipgloss.Color("#262626"))
 		sections = append(sections, insecureStyle.Render(insecureLabel))
 		sections = append(sections, "")
 		for _, gem := range m.InsecureSourceGems {
@@ -2134,10 +2137,12 @@ func (m *Model) formatInfoLine(label string, value string) string {
 	}
 
 	labelStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color(ColorTextMuted))
+		Foreground(lipgloss.Color(ColorTextMuted)).
+		Background(lipgloss.Color("#262626"))
 
 	valueStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color(ColorText))
+		Foreground(lipgloss.Color(ColorText)).
+		Background(lipgloss.Color("#262626"))
 
 	return fmt.Sprintf("  %s: %s",
 		labelStyle.Render(label),

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -2122,13 +2122,18 @@ func (m *Model) renderProjectInfo(height int) string {
 		}
 	}
 
-	// Padding to fill height
-	lines := sections
-	for len(lines) < height {
-		lines = append(lines, AppBackgroundStyle.Width(m.Width).Render(""))
+	// Pad each line to full width with background color
+	var paddedLines []string
+	for _, line := range sections {
+		paddedLines = append(paddedLines, AppBackgroundStyle.Width(m.Width).Render(line))
 	}
 
-	return lipgloss.JoinVertical(lipgloss.Left, lines[:height]...)
+	// Padding to fill height
+	for len(paddedLines) < height {
+		paddedLines = append(paddedLines, AppBackgroundStyle.Width(m.Width).Render(""))
+	}
+
+	return lipgloss.JoinVertical(lipgloss.Left, paddedLines[:height]...)
 }
 
 func (m *Model) formatInfoLine(label string, value string) string {


### PR DESCRIPTION
## Summary
- Fix sentry-cli workflow for v3.3.5 (removes unsupported `releases upload` command)
- Fix Project Information tab background color gaps (lines now fill full width)

## Test plan
- [x] Linter passed
- [x] All tests passed
- [x] Manual test: Project tab displays with full background coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)