### PR TITLE
feat: add GitHub source support for Gemfile custom repos

### DIFF
--- a/internal/gemfile/analyzer.go
+++ b/internal/gemfile/analyzer.go
@@ -36,6 +36,10 @@ type GemStatus struct {
 	Constraint string
 	// UpdateableVersion is the highest version matching the constraint
 	UpdateableVersion string
+	// GitHubSource is the GitHub source from Gemfile (e.g., "owner/repo")
+	GitHubSource string
+	// GitHubRef is the git ref from Gemfile (commit SHA, branch, tag)
+	GitHubRef string
 }
 
 // AnalysisResult contains the results of analyzing a Gemfile.lock for vulnerabilities,
@@ -82,10 +86,12 @@ func Analyze(gemfile *Gemfile) *AnalysisResult {
 	// Check each gem for vulnerable and outdated status
 	for _, gem := range allGems {
 		status := &GemStatus{
-			Name:       gem.Name,
-			Version:    gem.Version,
-			Groups:     gem.Groups, // Copy group information
-			Constraint: gem.Constraint,
+			Name:         gem.Name,
+			Version:      gem.Version,
+			Groups:       gem.Groups, // Copy group information
+			Constraint:   gem.Constraint,
+			GitHubSource: gem.GitHubSource,
+			GitHubRef:    gem.GitHubRef,
 		}
 
 		// Note: Vulnerability checking is deferred to OSV.dev async scan in the UI.

--- a/internal/gemfile/outdated.go
+++ b/internal/gemfile/outdated.go
@@ -71,6 +71,10 @@ type OutdatedChecker struct {
 	versionCreatedAts map[string]string
 	// dependencies maps gem names to their dependency lists (for gemspec enrichment)
 	dependencies map[string][]string
+	// gemfileGitHubSources maps gem names to their GitHub source from Gemfile (owner/repo format)
+	gemfileGitHubSources map[string]string
+	// gemfileGitHubRefs maps gem names to their git ref from Gemfile
+	gemfileGitHubRefs map[string]string
 }
 
 // NewOutdatedChecker creates a new OutdatedChecker with a 10-second HTTP timeout
@@ -80,12 +84,14 @@ func NewOutdatedChecker() *OutdatedChecker {
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 		},
-		cache:             make(map[string]string),
-		homepages:         make(map[string]string),
-		descriptions:      make(map[string]string),
-		sourceCodeURIs:    make(map[string]string),
-		versionCreatedAts: make(map[string]string),
-		dependencies:      make(map[string][]string),
+		cache:                make(map[string]string),
+		homepages:            make(map[string]string),
+		descriptions:         make(map[string]string),
+		sourceCodeURIs:       make(map[string]string),
+		versionCreatedAts:    make(map[string]string),
+		dependencies:         make(map[string][]string),
+		gemfileGitHubSources: make(map[string]string),
+		gemfileGitHubRefs:    make(map[string]string),
 	}
 }
 
@@ -513,4 +519,46 @@ func isVersionLess(v1, v2 string) bool {
 	}
 
 	return false
+}
+
+// SetGitHubSource stores the GitHub source from the Gemfile for a gem.
+// This allows us to display the correct reference URL when users specify a custom fork.
+func (oc *OutdatedChecker) SetGitHubSource(gemName, githubSource, ref string) {
+	oc.mu.Lock()
+	defer oc.mu.Unlock()
+	oc.gemfileGitHubSources[gemName] = githubSource
+	oc.gemfileGitHubRefs[gemName] = ref
+}
+
+// GetGitHubURL returns the GitHub URL for a gem.
+// It prefers the Gemfile-specified source over the rubygems.org source.
+// Returns empty string if no GitHub source is available.
+func (oc *OutdatedChecker) GetGitHubURL(gemName string) string {
+	oc.mu.Lock()
+	defer oc.mu.Unlock()
+
+	// First check if there's a Gemfile-specified GitHub source
+	if source, ok := oc.gemfileGitHubSources[gemName]; ok && source != "" {
+		return fmt.Sprintf("https://github.com/%s", source)
+	}
+
+	// Fall back to rubygems.org source code URI
+	if sourceURI, ok := oc.sourceCodeURIs[gemName]; ok && sourceURI != "" {
+		// Extract owner/repo from source_code_uri (e.g., https://github.com/owner/repo)
+		if idx := strings.Index(sourceURI, "github.com/"); idx >= 0 {
+			path := sourceURI[idx+len("github.com/"):]
+			// Remove .git suffix if present
+			path = strings.TrimSuffix(path, ".git")
+			return fmt.Sprintf("https://github.com/%s", path)
+		}
+	}
+
+	return ""
+}
+
+// GetGitHubRef returns the git ref (commit SHA, branch, or tag) from the Gemfile.
+func (oc *OutdatedChecker) GetGitHubRef(gemName string) string {
+	oc.mu.Lock()
+	defer oc.mu.Unlock()
+	return oc.gemfileGitHubRefs[gemName]
 }

--- a/internal/gemfile/parser.go
+++ b/internal/gemfile/parser.go
@@ -38,6 +38,10 @@ type Gem struct {
 	InsecureSource bool
 	// Constraint is the version constraint from Gemfile/gems.rb/gemspec (e.g., "~> 7.2", ">= 1.0")
 	Constraint string
+	// GitHubSource stores the GitHub source from Gemfile (e.g., "owner/repo" for github: option)
+	GitHubSource string
+	// GitHubRef stores the git ref from Gemfile (commit SHA, branch, tag)
+	GitHubRef string
 }
 
 // Gemfile represents the parsed contents of a Gemfile.lock file.
@@ -729,4 +733,52 @@ func isVersionConstraint(s string) bool {
 		strings.HasPrefix(s, "=") ||
 		// Also match plain version numbers (e.g., "1.2.3")
 		(s[0] >= '0' && s[0] <= '9')
+}
+
+// LoadGitHubSourcesFromGemfile parses the Gemfile to extract GitHub sources specified via the github: option.
+// This allows gemtracker to display the correct reference URL when users use a fork/custom repo.
+// Example: gem "gemname", github: "owner/repo", ref: "abc123"
+func (g *Gemfile) LoadGitHubSourcesFromGemfile(gemfilePath string) error {
+	gemfilePath = resolvePath(gemfilePath, FindGemfile)
+	if gemfilePath == "" {
+		return nil
+	}
+
+	logger.Info("Loading GitHub sources from Gemfile: %s", gemfilePath)
+
+	file, err := os.Open(gemfilePath)
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	githubLineRegex := regexp.MustCompile(`^\s*gem\s+["']([a-z0-9_-]+)["'].*github:\s+["']([^"']+)["']`)
+	refLineRegex := regexp.MustCompile(`ref:\s+["']([^"']+)["']`)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		matches := githubLineRegex.FindStringSubmatch(line)
+		if len(matches) < 3 {
+			continue
+		}
+
+		gemName := matches[1]
+		githubSource := matches[2]
+
+		refMatch := refLineRegex.FindStringSubmatch(line)
+		var ref string
+		if len(refMatch) > 1 {
+			ref = refMatch[1]
+		}
+
+		if gem, ok := g.Gems[gemName]; ok {
+			gem.GitHubSource = githubSource
+			gem.GitHubRef = ref
+			logger.Info("Loaded GitHub source for %s: %s (ref: %s)", gemName, githubSource, ref)
+		}
+	}
+
+	return nil
 }

--- a/internal/gemfile/parser_test.go
+++ b/internal/gemfile/parser_test.go
@@ -633,3 +633,123 @@ DEPENDENCIES
 		t.Errorf("expected 2 insecure gems, got %d", len(insecureGems))
 	}
 }
+
+func TestLoadGitHubSourcesFromGemfile(t *testing.T) {
+	// Create a temporary directory with both Gemfile and Gemfile.lock
+	dir := t.TempDir()
+
+	lockContent := `GIT
+  remote: https://github.com/BranchIntl/advanced-sneakers-activejob.git
+  revision: 70aae88422b7ceadc48641d93fffe7b9abc73137
+  branch: master
+  specs:
+    advanced-sneakers-activejob (0.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (7.0.0)
+
+PLATFORMS
+  ruby
+`
+
+	gemfileContent := `source "https://rubygems.org"
+
+gem "advanced-sneakers-activejob", github: "BranchIntl/advanced-sneakers-activejob", ref: "70aae88422b7ceadc48641d93fffe7b9abc73137"
+gem "rails"
+`
+
+	lockPath := filepath.Join(dir, "Gemfile.lock")
+	gemfilePath := filepath.Join(dir, "Gemfile")
+
+	if err := os.WriteFile(lockPath, []byte(lockContent), 0644); err != nil {
+		t.Fatalf("failed to write Gemfile.lock: %v", err)
+	}
+
+	if err := os.WriteFile(gemfilePath, []byte(gemfileContent), 0644); err != nil {
+		t.Fatalf("failed to write Gemfile: %v", err)
+	}
+
+	gf, err := Parse(lockPath)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	// Load GitHub sources
+	err = gf.LoadGitHubSourcesFromGemfile(dir)
+	if err != nil {
+		t.Fatalf("LoadGitHubSourcesFromGemfile failed: %v", err)
+	}
+
+	// Check that GitHub source was loaded for custom gem
+	customGem := gf.Gems["advanced-sneakers-activejob"]
+	if customGem == nil {
+		t.Fatal("expected advanced-sneakers-activejob gem to be parsed")
+	}
+	if customGem.GitHubSource != "BranchIntl/advanced-sneakers-activejob" {
+		t.Errorf("expected GitHub source 'BranchIntl/advanced-sneakers-activejob', got %s", customGem.GitHubSource)
+	}
+	if customGem.GitHubRef != "70aae88422b7ceadc48641d93fffe7b9abc73137" {
+		t.Errorf("expected GitHub ref '70aae88422b7ceadc48641d93fffe7b9abc73137', got %s", customGem.GitHubRef)
+	}
+
+	// Check that rails (without github:) has no GitHub source
+	rails := gf.Gems["rails"]
+	if rails == nil {
+		t.Fatal("expected rails gem to be parsed")
+	}
+	if rails.GitHubSource != "" {
+		t.Errorf("expected no GitHub source for rails, got %s", rails.GitHubSource)
+	}
+}
+
+func TestLoadGitHubSourcesFromGemfile_NoRef(t *testing.T) {
+	// Test GitHub source without ref
+	dir := t.TempDir()
+
+	lockContent := `GEM
+  remote: https://rubygems.org/
+  specs:
+    mygem (1.0.0)
+
+PLATFORMS
+  ruby
+`
+
+	gemfileContent := `source "https://rubygems.org"
+
+gem "mygem", github: "customfork/mygem"
+`
+
+	lockPath := filepath.Join(dir, "Gemfile.lock")
+	gemfilePath := filepath.Join(dir, "Gemfile")
+
+	if err := os.WriteFile(lockPath, []byte(lockContent), 0644); err != nil {
+		t.Fatalf("failed to write Gemfile.lock: %v", err)
+	}
+	if err := os.WriteFile(gemfilePath, []byte(gemfileContent), 0644); err != nil {
+		t.Fatalf("failed to write Gemfile: %v", err)
+	}
+
+	gf, err := Parse(lockPath)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	err = gf.LoadGitHubSourcesFromGemfile(dir)
+	if err != nil {
+		t.Fatalf("LoadGitHubSourcesFromGemfile failed: %v", err)
+	}
+
+	mygem := gf.Gems["mygem"]
+	if mygem == nil {
+		t.Fatal("expected mygem gem to be parsed")
+	}
+	if mygem.GitHubSource != "customfork/mygem" {
+		t.Errorf("expected GitHub source 'customfork/mygem', got %s", mygem.GitHubSource)
+	}
+	if mygem.GitHubRef != "" {
+		t.Errorf("expected no GitHub ref, got %s", mygem.GitHubRef)
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -604,6 +604,8 @@ func performAnalysis(gemfilePath string, noCache bool) tea.Cmd {
 			gf.LoadGroupsFromGemfile(dir)
 			// Load version constraints from Gemfile/gems.rb
 			gf.LoadConstraintsFromGemfile(dir)
+			// Load GitHub sources from Gemfile (custom forks)
+			gf.LoadGitHubSourcesFromGemfile(dir)
 			// Load constraints from gemspec if present
 			gf.LoadConstraintsFromGemspec("")
 		}
@@ -657,6 +659,8 @@ func performAnalysisWithProgress(gemfilePath string) tea.Cmd {
 		gf.LoadGroupsFromGemfile(dir)
 		// Load version constraints from Gemfile/gems.rb
 		gf.LoadConstraintsFromGemfile(dir)
+		// Load GitHub sources from Gemfile (custom forks)
+		gf.LoadGitHubSourcesFromGemfile(dir)
 		// Load constraints from gemspec if present
 		gf.LoadConstraintsFromGemspec("")
 
@@ -720,6 +724,8 @@ func performAnalysisWithProgressStages(gemfilePath string) tea.Cmd {
 			gf.LoadGroupsFromGemfile(dir)
 			// Load version constraints from Gemfile/gems.rb
 			gf.LoadConstraintsFromGemfile(dir)
+			// Load GitHub sources from Gemfile (custom forks)
+			gf.LoadGitHubSourcesFromGemfile(dir)
 			// Load constraints from gemspec if present
 			gf.LoadConstraintsFromGemspec("")
 
@@ -757,6 +763,8 @@ func performDependencyAnalysis(gemfilePath string, gemName string) tea.Cmd {
 			gf.LoadGroupsFromGemfile(dir)
 			// Load version constraints from Gemfile/gems.rb
 			gf.LoadConstraintsFromGemfile(dir)
+			// Load GitHub sources from Gemfile (custom forks)
+			gf.LoadGitHubSourcesFromGemfile(dir)
 			// Load constraints from gemspec if present
 			gf.LoadConstraintsFromGemspec("")
 		}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -1272,6 +1272,16 @@ func (m *Model) handleAnalysisComplete(msg AnalysisCompleteMsg) (tea.Model, tea.
 	m.processAnalysisGems(msg.Result)
 	m.populateProjectInfo(msg.Result)
 	m.updateAnalysisState(msg)
+
+	// Transfer GitHub sources from GemStatus to OutdatedChecker
+	if msg.Result != nil && msg.Result.GemStatuses != nil && m.OutdatedChecker != nil {
+		for _, gem := range msg.Result.GemStatuses {
+			if gem.GitHubSource != "" {
+				m.OutdatedChecker.SetGitHubSource(gem.Name, gem.GitHubSource, gem.GitHubRef)
+			}
+		}
+	}
+
 	m.setupOutdatedChecking(msg.Result)
 	m.setupHealthChecking()
 	m.setupUpdateableChecking(msg.Result)
@@ -1595,8 +1605,20 @@ func (m *Model) handleOutdatedItem(msg OutdatedItemMsg) (tea.Model, tea.Cmd) {
 			if gem.Name == msg.GemName {
 				gem.IsOutdated = msg.IsOutdated
 				gem.LatestVersion = msg.LatestVersion
-				gem.HomepageURL = msg.HomepageURL
 				gem.Description = msg.Description
+
+				// Prefer GitHub source from Gemfile over rubygems.org homepage
+				if gem.GitHubSource != "" && m.OutdatedChecker != nil {
+					githubURL := m.OutdatedChecker.GetGitHubURL(gem.Name)
+					if githubURL != "" {
+						gem.HomepageURL = githubURL
+					} else {
+						gem.HomepageURL = msg.HomepageURL
+					}
+				} else {
+					gem.HomepageURL = msg.HomepageURL
+				}
+
 				// If gem has no constraint, updateable version = latest version
 				if gem.Constraint == "" {
 					gem.UpdateableVersion = msg.LatestVersion


### PR DESCRIPTION
Parse github: and ref: options from Gemfile to display the correct reference URL when users specify custom forks instead of the default rubygems.org source.

This addresses issue #96 by ensuring that gems with custom GitHub sources (e.g., github: "BranchIntl/advanced-sneakers-activejob") display the correct repository URL rather than the default one.

Changes:
- Add GitHubSource and GitHubRef fields to Gem and GemStatus structs
- Add LoadGitHubSourcesFromGemfile() to parse Gemfile github: options
- Add SetGitHubSource/GetGitHubURL to OutdatedChecker
- Prefer GitHub source from Gemfile over rubygems.org homepage