### PR TITLE
fix(release): change goreleaser mode from append to replace

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,7 +51,7 @@ release:
   draft: false
   prerelease: false
   name_template: "{{ .ProjectName }} {{ .Version }}"
-  mode: append
+  mode: replace
 
 changelog:
   use: git


### PR DESCRIPTION
Prevent 'immutable release' errors when uploading assets to published releases.

Replace mode deletes and recreates the release, avoiding conflicts with existing published releases.

Fixes v1.2.11 release failure.